### PR TITLE
Worker snapshot and variance repeat

### DIFF
--- a/core/LAMMPSSimulator.cpp
+++ b/core/LAMMPSSimulator.cpp
@@ -415,8 +415,12 @@ void LAMMPSSimulator::sample(double r, double T,
   results["TdX"] = (*lmp_ptr);
   lammps_free(lmp_ptr);
 
-  // post minmization - max jump
-
+	if(params->workerDump) {
+		cmd = "write_data "+params->dump_dir;
+		cmd += "/worker_snapshot_"+std::to_string(tag)+"_"+std::to_string(r)+".dat";
+		run_commands(cmd);
+	}
+	// post minmization - max jump
   if(params->postMin) {
     cmd = "min_style fire\n minimize 0 0.01 ";
     cmd += params->parameters["MinSteps"]+" "+params->parameters["MinSteps"];

--- a/core/Parser.cpp
+++ b/core/Parser.cpp
@@ -129,6 +129,13 @@ void Parser::set_parameters() {
   spline_path = bool(std::stoi(parameters["SplinePath"]));
   match_planes = !bool(std::stoi(parameters["Rediscretize"]));
   real_coord = bool(std::stoi(parameters["RealMEPDist"]));
+  use_custom_positions = bool(std::stoi(parameters["UseCustomPositions"]));
+
+  std::stringstream ss(parameters["CustomPositions"]);
+  std::istream_iterator<std::string> begin(ss);
+  std::istream_iterator<std::string> end;
+  std::vector<std::string> tokens(begin, end);
+  for (auto &s: tokens) custom_positions.push_back(std::stod(s));
 };
 
 void Parser::overwrite_xml(int nProcs) {
@@ -152,7 +159,13 @@ void Parser::overwrite_xml(int nProcs) {
   parameters["ReSampleThresh"] = "0.5";
   parameters["maxExtraRepeats"] = "1";
   parameters["ForceErrorThresh"] = "1.0";
-
+  parameters["UseCustomPositions"] = "0.0";
+  parameters["CustomPositions"] = "0.0 1.0";
+  std::stringstream ss(parameters["CustomPositions"]);
+  std::istream_iterator<std::string> begin(ss);
+  std::istream_iterator<std::string> end;
+  std::vector<std::string> tokens(begin, end);
+  for (auto &s: tokens) custom_positions.push_back(std::stod(s));
   //parameters["postMin"] = "1";
   //parameters["PreMin"] = "1";
 };

--- a/core/Parser.cpp
+++ b/core/Parser.cpp
@@ -45,6 +45,7 @@ Parser::Parser(std::string file, bool test) {
   parameters["ReSampleThresh"] = "0.5";
   parameters["maxExtraRepeats"] = "1";
   parameters["postMin"] = "0";
+	parameters["workerDump"] = "0";
   parameters["PreMin"] = "1";
   parameters["SplinePath"] = "1";
   parameters["MatchPlanes"] = "0";
@@ -125,6 +126,7 @@ void Parser::set_parameters() {
   f_error_thresh = std::stod(parameters["ForceErrorThresh"]);
   maxExtraRepeats = std::stoi(parameters["maxExtraRepeats"]);
   postMin = bool(std::stoi(parameters["postMin"]));
+  workerDump = bool(std::stoi(parameters["workerDump"]));
   preMin = bool(std::stoi(parameters["PreMin"]));
   spline_path = bool(std::stoi(parameters["SplinePath"]));
   match_planes = !bool(std::stoi(parameters["Rediscretize"]));

--- a/core/Parser.cpp
+++ b/core/Parser.cpp
@@ -50,6 +50,7 @@ Parser::Parser(std::string file, bool test) {
   parameters["MatchPlanes"] = "0";
   parameters["RealMEPDist"] = "1";
   parameters["FixPAFIGroup"] = "all";
+  parameters["FixPAFIGroup"] = "all";
 
 
   seeded = false;
@@ -121,13 +122,13 @@ void Parser::set_parameters() {
   loglammps = bool(std::stoi(parameters["LogLammps"]));
   maxjump_thresh = std::stod(parameters["MaxJump"]);
   redo_thresh = std::stod(parameters["ReSampleThresh"]);
+  f_error_thresh = std::stod(parameters["ForceErrorThresh"]);
   maxExtraRepeats = std::stoi(parameters["maxExtraRepeats"]);
   postMin = bool(std::stoi(parameters["postMin"]));
   preMin = bool(std::stoi(parameters["PreMin"]));
   spline_path = bool(std::stoi(parameters["SplinePath"]));
   match_planes = !bool(std::stoi(parameters["Rediscretize"]));
   real_coord = bool(std::stoi(parameters["RealMEPDist"]));
-
 };
 
 void Parser::overwrite_xml(int nProcs) {
@@ -150,6 +151,7 @@ void Parser::overwrite_xml(int nProcs) {
   parameters["MaxJump"] = "0.1";
   parameters["ReSampleThresh"] = "0.5";
   parameters["maxExtraRepeats"] = "1";
+  parameters["ForceErrorThresh"] = "1.0";
 
   //parameters["postMin"] = "1";
   //parameters["PreMin"] = "1";

--- a/core/Parser.hpp
+++ b/core/Parser.hpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <iostream>
 #include <random>
+#include <algorithm>
+#include <iterator>
 
 #include "rapidxml.hpp"
 
@@ -44,11 +46,12 @@ std::map<std::string,std::string> parameters;
 std::map<std::string,std::string> scripts;
 
 std::vector<std::string> PathwayConfigurations;
+std::vector<double> custom_positions;
 double lowT,highT,Friction,startr,stopr,maxjump_thresh,redo_thresh,f_error_thresh;
 int CoresPerWorker, nPlanes, TSteps, nRepeats, maxExtraRepeats;
 unsigned random_seed;
 std::string dump_dir;
-bool seeded,loglammps,postMin,preMin,xml_success,spline_path,match_planes,real_coord;
+bool seeded,loglammps,postMin,preMin,xml_success,spline_path,match_planes,real_coord,use_custom_positions;
 
 private:
   std::mt19937 rng;

--- a/core/Parser.hpp
+++ b/core/Parser.hpp
@@ -44,7 +44,7 @@ std::map<std::string,std::string> parameters;
 std::map<std::string,std::string> scripts;
 
 std::vector<std::string> PathwayConfigurations;
-double lowT,highT,Friction,startr,stopr,maxjump_thresh,redo_thresh;
+double lowT,highT,Friction,startr,stopr,maxjump_thresh,redo_thresh,f_error_thresh;
 int CoresPerWorker, nPlanes, TSteps, nRepeats, maxExtraRepeats;
 unsigned random_seed;
 std::string dump_dir;

--- a/core/Parser.hpp
+++ b/core/Parser.hpp
@@ -51,7 +51,8 @@ double lowT,highT,Friction,startr,stopr,maxjump_thresh,redo_thresh,f_error_thres
 int CoresPerWorker, nPlanes, TSteps, nRepeats, maxExtraRepeats;
 unsigned random_seed;
 std::string dump_dir;
-bool seeded,loglammps,postMin,preMin,xml_success,spline_path,match_planes,real_coord,use_custom_positions;
+bool seeded,loglammps,postMin,preMin,xml_success,spline_path;
+bool workerDump,match_planes,real_coord,use_custom_positions;
 
 private:
   std::mt19937 rng;

--- a/example/sample_run/config.xml
+++ b/example/sample_run/config.xml
@@ -3,16 +3,16 @@
   <DumpFolder>./dumps</DumpFolder>
 
   <!-- LowTemperature to HighTemperature in TemperatureSteps steps -->
-  <LowTemperature> 200 </LowTemperature>
+  <LowTemperature> 800 </LowTemperature>
   <HighTemperature> 800 </HighTemperature>
-  <TemperatureSteps> 4 </TemperatureSteps>
+  <TemperatureSteps> 1 </TemperatureSteps>
 
   <!-- We require nprocs % CoresPerWorker==0 -->
   <CoresPerWorker> 1 </CoresPerWorker>
 
   <!-- Number of samples per plane per worker -->
   <nRepeats> 1 </nRepeats>
-  <ForceErrorThresh> 0.01 </ForceErrorThresh>
+  <ForceErrorThresh> 0.1 </ForceErrorThresh>
 
   <!-- Data gathering steps -->
   <SampleSteps> 10 </SampleSteps>
@@ -22,6 +22,10 @@
 
   <!-- Max steps for optional in-plane minimizations (see below) -->
   <MinSteps> 1000 </MinSteps>
+
+  <!-- Custom knot positions -->
+  <UseCustomPositions>0</UseCustomPositions>  
+  <CustomPositions>0. 0.16 0.223 0.3 0.4 0.5</CustomPositions>
 
   <!--
     RELATIVE thermal expansion coefficients along X,Y,Z directions of simulation-
@@ -54,7 +58,7 @@
    0 : (Default) Output time-and-ensemble averaged in-plane deviation from reference pathway. Can indicate finite temperature path but will have sampling noise
    1 : Output ensemble averaged in-plane deviation following in-plane minimization post-run. No noise but will lose some/all features of path
   -->
-  <postMin> 0 </postMin>
+  <postMin> 1 </postMin>
 
   <!--
   Perform an in-plane minimization before thermalization/sampling.

--- a/example/sample_run/config.xml
+++ b/example/sample_run/config.xml
@@ -15,13 +15,13 @@
   <ForceErrorThresh> 0.1 </ForceErrorThresh>
 
   <!-- Data gathering steps -->
-  <SampleSteps> 10 </SampleSteps>
+  <SampleSteps> 100 </SampleSteps>
 
   <!-- Steps for thermalization -->
-  <ThermSteps> 10 </ThermSteps>
+  <ThermSteps> 100 </ThermSteps>
 
   <!-- Max steps for optional in-plane minimizations (see below) -->
-  <MinSteps> 1000 </MinSteps>
+  <MinSteps> 100 </MinSteps>
 
   <!-- Custom knot positions for integration TEST FEATURE-->
   <UseCustomPositions>0</UseCustomPositions>  
@@ -59,6 +59,11 @@
    1 : Output ensemble averaged in-plane deviation following in-plane minimization post-run. No noise but will lose some/all features of path
   -->
   <postMin> 1 </postMin>
+
+	<!--
+		Dump "hot" snapshot after each run. For development only!
+	-->
+  <workerDump> 1 </workerDump>
 
   <!--
   Perform an in-plane minimization before thermalization/sampling.

--- a/example/sample_run/config.xml
+++ b/example/sample_run/config.xml
@@ -23,7 +23,7 @@
   <!-- Max steps for optional in-plane minimizations (see below) -->
   <MinSteps> 1000 </MinSteps>
 
-  <!-- Custom knot positions -->
+  <!-- Custom knot positions for integration TEST FEATURE-->
   <UseCustomPositions>0</UseCustomPositions>  
   <CustomPositions>0. 0.16 0.223 0.3 0.4 0.5</CustomPositions>
 

--- a/example/sample_run/config.xml
+++ b/example/sample_run/config.xml
@@ -12,12 +12,13 @@
 
   <!-- Number of samples per plane per worker -->
   <nRepeats> 1 </nRepeats>
+  <ForceErrorThresh> 0.01 </ForceErrorThresh>
 
   <!-- Data gathering steps -->
-  <SampleSteps> 1000 </SampleSteps>
+  <SampleSteps> 10 </SampleSteps>
 
   <!-- Steps for thermalization -->
-  <ThermSteps> 1000 </ThermSteps>
+  <ThermSteps> 10 </ThermSteps>
 
   <!-- Max steps for optional in-plane minimizations (see below) -->
   <MinSteps> 1000 </MinSteps>
@@ -95,7 +96,7 @@
   <ReSampleThresh> 0.8 </ReSampleThresh>
 
   <!-- How many resample attempts -->
-  <maxExtraRepeats> 1 </maxExtraRepeats>
+  <maxExtraRepeats> 10 </maxExtraRepeats>
 
   <!--
   Sequential list of pathway configurations,

--- a/pafi/pafi.cpp
+++ b/pafi/pafi.cpp
@@ -161,7 +161,7 @@ int main(int narg, char **arg) {
     if(params.spline_path and not params.match_planes) {
     for (double r = params.startr; r <= params.stopr+0.5*dr; r += dr )
       sample_r.push_back(r);
-    } else for(auto r: sim.pathway_r) if(r>=0.0 && r<=1.0) sample_r.push_back(r);
+    } else for(auto r: sim.pathway_r) if(r>=params.startr-0.02 && r<=params.stopr+0.02) sample_r.push_back(r);
   }
   
 

--- a/pafi/pafi.cpp
+++ b/pafi/pafi.cpp
@@ -120,9 +120,10 @@ int main(int narg, char **arg) {
 
   const int vsize = 3 * sim.natoms;
   const int rsize = nRes*nWorkers;
-
+  bool not_finished_sampling;
   int total_valid_data, totalRepeats, total_invalid_data;
-  double temp, dr, t_max_jump, p_jump;
+  double temp, dr, t_max_jump, p_jump, f_mean;
+  double *f_error = new double[1];
   std::string rstr,Tstr,dump_fn,fn,dump_suffix;
   std::map<std::string,double> results;
 
@@ -215,7 +216,8 @@ int main(int narg, char **arg) {
       total_valid_data=0;
       totalRepeats=0;
       t_max_jump=0.0;
-      while (total_valid_data<=int(params.redo_thresh*nWorkers*nRepeats)) {
+      not_finished_sampling = true;
+      while (not_finished_sampling) {
 
         sim.sample(r, T, results, local_dev);
         double aa=0.0;
@@ -279,6 +281,25 @@ int main(int narg, char **arg) {
                                 "Try a lower temperature. See README for tips";
           break;
         }
+        not_finished_sampling = bool(total_valid_data<=int(params.redo_thresh*nWorkers*nRepeats));
+
+        // determine force error
+        f_error[0]=0.0;
+        if(rank==0){
+          f_mean = 0.0;
+          for (int i=0;i<total_valid_data;i++)
+            f_mean += valid_res[i*nRes+2] / double(total_valid_data);
+          for (int i=0;i<total_valid_data;i++) {
+            // we have N^2 as require standard error on mean
+            temp = (f_mean-valid_res[i*nRes+2]) / double(total_valid_data);
+            f_error[0] += temp * temp ;
+          }
+          f_error[0] = std::sqrt(f_error[0]);
+        }
+        MPI_Bcast(f_error,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+        
+        not_finished_sampling += bool(f_error[0] >= params.f_error_thresh);
+
         if(rank==0) std::cout<<"#"<<std::flush;
       }
       // collate
@@ -317,13 +338,13 @@ int main(int narg, char **arg) {
 
         for(int i=0;i<total_valid_data;i++) for(int j=0;j<nRes;j++) {
           temp = valid_res[i*nRes+j]-final_res[j];
-          final_res[j+nRes] += temp * temp;
+          final_res[j+nRes] += temp * temp / double(total_valid_data);
         }
         // under assumption that sample time is longer than autocorrelations,
         // expected variance in time average is ensemble variance / nWorkers
         // raw_output gives data to confirm this assumption (CLT with grouping)
         if(total_valid_data>0) for(int j=0;j<nRes;j++)
-          final_res[j+nRes] = sqrt(final_res[j+nRes])/double(total_valid_data);
+          final_res[j+nRes] = sqrt(final_res[j+nRes])/sqrt(double(total_valid_data));
 
         integr.push_back(r);
         dfer.push_back(final_res[2]); // <dF/dr>

--- a/pafi/pafi.cpp
+++ b/pafi/pafi.cpp
@@ -152,11 +152,18 @@ int main(int narg, char **arg) {
   else dr = 0.1;
 
   std::vector<double> sample_r;
-  if(params.spline_path and not params.match_planes) {
+  if(params.use_custom_positions) {
+    for(auto r: params.custom_positions) {
+      sample_r.push_back(r);
+      std::cout<<r<<std::endl;
+    }
+  } else {
+    if(params.spline_path and not params.match_planes) {
     for (double r = params.startr; r <= params.stopr+0.5*dr; r += dr )
       sample_r.push_back(r);
-  } else for(auto r: sim.pathway_r) if(r>=0.0 && r<=1.0) sample_r.push_back(r);
-
+    } else for(auto r: sim.pathway_r) if(r>=0.0 && r<=1.0) sample_r.push_back(r);
+  }
+  
 
 
   for(double T = params.lowT; T <= params.highT;) {

--- a/utils/pafi-path-test.cpp
+++ b/utils/pafi-path-test.cpp
@@ -194,12 +194,19 @@ int main(int narg, char **arg) {
     std::cout<<"\n";
   }
 
+
   std::vector<double> sample_r;
-  if(params.spline_path and not params.match_planes) {
+  if(params.use_custom_positions) {
+    for(auto r: params.custom_positions) {
+      sample_r.push_back(r);
+      std::cout<<r<<std::endl;
+    }
+  } else {
+    if(params.spline_path and not params.match_planes) {
     for (double r = params.startr; r <= params.stopr+0.5*dr; r += dr )
       sample_r.push_back(r);
-  } else for(auto r: sim.pathway_r)
-    if(r>=params.startr-0.02 && r<=params.stopr+0.02) sample_r.push_back(r);
+    } else for(auto r: sim.pathway_r) if(r>=params.startr-0.02 && r<=params.stopr+0.02) sample_r.push_back(r);
+  }
 
   for(auto r: sample_r) {
     valid_res.clear();


### PR DESCRIPTION
This PR implements two features that live in separate branches and were not merged yet. The Variance repeat feature is somehow still experimental so we might prefer to wait before merge or merge to some type of `development` branch. For now I needed these two features in the same branch, which is the main motivation of the PR.

**Feat 1: Worker snapshot:** save 'hot' configurations after thermalization+sampling. Useful to visualize them / build a database of finite temperature configurations along a transition path. 
Added options: 

`<workerDump>1</workerDump>` (0/1 flag to activate the feature)


**Feat 2: Variance repeat:** provide additional controls to allow variance reduction by better attributing sampling effort.

Added options:

`<ForceErrorThresh> 0.1 </ForceErrorThresh>` Perform extra repeats until force error is converged, to add extra sampling effort where variance is large. Total number of extra repeats is kept below `maxExtraRepeats`.

`<UseCustomPositions>1</UseCustomPositions>` (0/1 flag to activate the feature)
`<CustomPositions>0. 0.16 0.223 0.3 0.4 0.5</CustomPositions>` List of custom positions to perform integration (space-separated). Useful to add nodes in a region where dF is large.